### PR TITLE
change mstop definition for noncyclical fitting

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -66,6 +66,13 @@ mstop.mboostLSS <- function(object, parameter = names(object), ...){
     names(RET) <- names(object)[parameter]
     if (length(RET) == 1)
         RET <- RET[[1]]
+    # change mstop for noncyclical fitting to scalar value with attribute of partitions
+    if (inherits(object, "nc_mboostLSS")) {
+      partitions = RET
+      RET = sum(RET)
+      attr(RET, "partitions") <- partitions
+    }
+    
     return(RET)
 }
 
@@ -273,8 +280,11 @@ print.mboostLSS <- function(x, ...){
     cat("\n")
     if (!is.null(attr(x, "call")))
         cat("Call:\n", deparse(attr(x, "call")), "\n\n", sep = "")
+    m = mstop(x)
+    if (inherits(x, "nc_mboostLSS"))
+      m = attr(m, "partitions")
     cat("Number of boosting iterations (mstop): ",
-        paste(names(mstop(x)), mstop(x), sep = " = ", collapse = ", "), "\n")
+        paste(names(x), m, sep = " = ", collapse = ", "), "\n")
     nus <- sapply(x, function(xi) xi$control$nu)
     cat("Step size: ",
         paste(names(nus), nus, sep = " = ", collapse = ", "), "\n\n")
@@ -328,10 +338,11 @@ summary.mboostLSS <- function(object, ...) {
     cat("\n")
     if (!is.null(attr(object, "call")))
         cat("Call:\n", deparse(attr(object, "call")), "\n\n", sep = "")
+    m = mstop(object)
+    if (inherits(object, "nc_mboostLSS"))
+      m = attr(m, "partitions")
     cat("Number of boosting iterations (mstop): ",
-        paste(names(mstop(object)), mstop(object),
-              sep = " = ", collapse = ", "),
-        "\n")
+        paste(names(object), m, sep = " = ", collapse = ", "), "\n")
     nus <- sapply(object, function(xi) xi$control$nu)
     cat("Step size: ",
         paste(names(nus), nus, sep = " = ", collapse = ", "), "\n\n")

--- a/R/methods.R
+++ b/R/methods.R
@@ -68,9 +68,9 @@ mstop.mboostLSS <- function(object, parameter = names(object), ...){
         RET <- RET[[1]]
     # change mstop for noncyclical fitting to scalar value with attribute of partitions
     if (inherits(object, "nc_mboostLSS")) {
-      partitions = RET
-      RET = sum(RET)
-      attr(RET, "partitions") <- partitions
+        partitions <- RET
+        RET <- sum(RET)
+        attr(RET, "partitions") <- partitions
     }
     
     return(RET)
@@ -280,9 +280,9 @@ print.mboostLSS <- function(x, ...){
     cat("\n")
     if (!is.null(attr(x, "call")))
         cat("Call:\n", deparse(attr(x, "call")), "\n\n", sep = "")
-    m = mstop(x)
+    m <- mstop(x)
     if (inherits(x, "nc_mboostLSS"))
-      m = attr(m, "partitions")
+        m <- attr(m, "partitions")
     cat("Number of boosting iterations (mstop): ",
         paste(names(x), m, sep = " = ", collapse = ", "), "\n")
     nus <- sapply(x, function(xi) xi$control$nu)
@@ -338,9 +338,9 @@ summary.mboostLSS <- function(object, ...) {
     cat("\n")
     if (!is.null(attr(object, "call")))
         cat("Call:\n", deparse(attr(object, "call")), "\n\n", sep = "")
-    m = mstop(object)
+    m <- mstop(object)
     if (inherits(object, "nc_mboostLSS"))
-      m = attr(m, "partitions")
+        m <- attr(m, "partitions")
     cat("Number of boosting iterations (mstop): ",
         paste(names(object), m, sep = " = ", collapse = ", "), "\n")
     nus <- sapply(object, function(xi) xi$control$nu)


### PR DESCRIPTION
Was actually way less work than I thought. 


Now `mstop()` returns a scalar value with the attributes partitions for noncyclical fitting.

See #19  