### PR TITLE
Fix stabsel plot #40

### DIFF
--- a/R/mboostLSS.R
+++ b/R/mboostLSS.R
@@ -182,6 +182,8 @@ mboostLSS_fit <- function(formula, data = list(), families = GaussianLSS(),
             # this is the case for boosting from the beginning
             if (is.null(attr(fit, "combined_risk")) | niter == 0) {
                 combined_risk <- vapply(fit, risk, numeric(1))
+            } else {
+               combined_risk <- attr(fit, "combined_risk")()
             }
 
             best <- which(names(fit) == tail(names(combined_risk), 1))

--- a/R/mboostLSS.R
+++ b/R/mboostLSS.R
@@ -183,7 +183,7 @@ mboostLSS_fit <- function(formula, data = list(), families = GaussianLSS(),
             if (is.null(attr(fit, "combined_risk")) | niter == 0) {
                 combined_risk <- vapply(fit, risk, numeric(1))
             } else {
-               combined_risk <- attr(fit, "combined_risk")()
+                combined_risk <- attr(fit, "combined_risk")()
             }
 
             best <- which(names(fit) == tail(names(combined_risk), 1))

--- a/tests/regtest-noncyclic_fitting.R
+++ b/tests/regtest-noncyclic_fitting.R
@@ -169,3 +169,12 @@ model <- glmboostLSS(y ~ ., families = NBinomialLSS(), data = dat,
 selected(model) # ok (at least in principle)
 selected(model, merge = TRUE) ## BROKEN
 
+
+## Check merged risk for reducing mstop to 0, and increasing it again does not contain an NA
+stopifnot(all(!is.na(risk(model, merge = TRUE))))
+mstop(model) = 0
+stopifnot(all(!is.na(risk(model, merge = TRUE))))
+mstop(model) = 10
+stopifnot(all(!is.na(risk(model, merge = TRUE))))
+
+

--- a/tests/regtest-noncyclic_fitting.R
+++ b/tests/regtest-noncyclic_fitting.R
@@ -172,9 +172,9 @@ selected(model, merge = TRUE) ## BROKEN
 
 ## Check merged risk for reducing mstop to 0, and increasing it again does not contain an NA
 stopifnot(all(!is.na(risk(model, merge = TRUE))))
-mstop(model) = 0
+mstop(model) <- 0
 stopifnot(all(!is.na(risk(model, merge = TRUE))))
-mstop(model) = 10
+mstop(model) <- 10
 stopifnot(all(!is.na(risk(model, merge = TRUE))))
 
 


### PR DESCRIPTION
Fix for #40 

Ok this was a really strange bug....


so what happend was that it if we reduce mstop to 0, the combined_risk got initialized again with an NA, which produced on NA element in the combined risk vector. 

I added another test for that...

I would have guessed that it should break more than only the plot of stabsel
